### PR TITLE
CMake: revert to 2.8.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@
 #   Francois Gindraud (2017)
 # Created: 07/04/2010
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.11)
 project (testnh CXX)
 
 # Compile options
-set (private-compile-options -std=c++11 -Wall -Weffc++ -Wshadow -Wconversion)
+set (CMAKE_CXX_FLAGS "-std=c++11 -Wall -Weffc++ -Wshadow -Wconversion")
 
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
@@ -34,7 +34,7 @@ IF(NOT BUILD_STATIC)
 ENDIF()
 IF(BUILD_STATIC)
   MESSAGE(STATUS "Static linkage requested.")
-  list (APPEND private-compile-options -static -static-libgcc)
+  set (CMAKE_CXX_FLAGS "-static -static-libgcc ${CMAKE_CXX_FLAGS}")
 ENDIF()
 
 # Find dependencies (add install directory to search)
@@ -63,81 +63,13 @@ SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING.txt")
 SET(CPACK_RESOURCE_FILE_AUTHORS "${CMAKE_SOURCE_DIR}/AUTHORS.txt")
 SET(CPACK_RESOURCE_FILE_INSTALL "${CMAKE_SOURCE_DIR}/INSTALL.txt")
 SET(CPACK_SOURCE_GENERATOR "TGZ")
-SET(CPACK_SOURCE_IGNORE_FILES
- "CMakeFiles"
- "Makefile"
- "_CPack_Packages"
- "CMakeCache.txt"
- ".*\\\\.cmake"
- ".*\\\\.git"
- ".*\\\\.gz"
- ".*\\\\.zip"
- ".*\\\\.deb"
- ".*\\\\.rpm"
- ".*\\\\.dmg"
- ".*\\\\.sh"
- ".*\\\\..*\\\\.swp"
- ".*stamp"
- "\\\\.sh"
- "examples/.*/.*\\\\BIC.*"
- "examples/.*/.*\\\\AIC.*"
- "examples/.*/.*\\\\.out"
- "examples/.*/.*\\\\.profile.*"
- "examples/.*/.*\\\\.message.*"
- "examples/.*/.*\\\\.ml.*"
- "examples/.*/.*\\\\.counts.*"
- "examples/.*/.*\\\\.cluster.*"
- "examples/.*/.*\\\\.params.*"
- "examples/.*/.*\\\\.infos"
- "examples/.*/.*\\\\.csv"
- "examples/.*/.*\\\\.R"
- "examples/.*/.*\\\\.txt"
- "examples/.*/treefile.*"
- "examples/.*/Figures/.*"
- "examples/.*/rst"
- "examples/.*/rst1"
- "examples/.*/rub"
- "examples/.*/lnf"
- "examples/.*/mlc"
- "examples/.*/4fold.nuc"
- "examples/.*/2NG.*"
- "examples/.*/PAML.*/rst"
- "examples/.*/PAML.*/rst1"
- "examples/.*/PAML.*/rub"
- "doc/testnh/"
- "doc/testnh\\\\.info"
- "doc/testnh\\\\.toc"
- "doc/testnh\\\\.vr"
- "doc/testnh\\\\.tp"
- "doc/testnh\\\\.log"
- "doc/testnh\\\\.fn"
- "doc/testnh\\\\.ky"
- "doc/testnh\\\\.cp"
- "doc/testnh\\\\.pg"
- "doc/testnh\\\\.aux"
- "doc/testnh\\\\.pdf"
- "man/.*\\\\.1.gz"
- "examples/.*/PAML.*/lnf"
- "examples/.*/PAML.*/mlc"
- "examples/.*/PAML.*/4fold.nuc"
- "examples/.*/PAML.*/2NG.*"
- "TestNH/\\\\..*"
- "TestNH/testnh"
- "TestNH/mapnh"
- "TestNH/partnh"
- "TestNH/randnh"
- "debian/tmp"
- "debian/testnh"
- "debian/testnh\\\\.substvars"
- "debian/testnh\\\\.debhelper"
- "debian/debhelper\\\\.log"
- "install_manifest.txt"
- "DartConfiguration.tcl"
- ${CPACK_SOURCE_IGNORE_FILES}
-)
-IF (MACOS)
-  SET(CPACK_GENERATOR "Bundle")
-ENDIF()
+# /!\ This assumes that an external build is used
+SET(CPACK_SOURCE_IGNORE_FILES 
+       "/build/" 
+       "/\\\\.git/" 
+       "/\\\\.gitignore" 
+       ${CPACK_SOURCE_IGNORE_FILES}
+       )
 
 SET(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
 SET(CPACK_DEBSOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}.orig")
@@ -145,14 +77,6 @@ INCLUDE(CPack)
 
 #This adds the 'dist' target
 ADD_CUSTOM_TARGET(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
-# 'clean' is not (yet) a first class target. However, we need to clean the directories before building the sources:
-IF("${CMAKE_GENERATOR}" MATCHES "Make")
-  ADD_CUSTOM_TARGET(make_clean
-    COMMAND ${CMAKE_MAKE_PROGRAM} clean
-    WORKING_DIRECTORY ${CMAKE_CURRENT_DIR}
-  )
-  ADD_DEPENDENCIES(dist make_clean)
-ENDIF()
 
 IF(NOT NO_DEP_CHECK)
 IF (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,42 @@ IF(BUILD_STATIC)
   set (CMAKE_CXX_FLAGS "-static -static-libgcc ${CMAKE_CXX_FLAGS}")
 ENDIF()
 
+# Check compression program
+# COMPRESS_PROGRAM controls the choice of program
+# COMPRESS_EXT can be used to override the file extension
+if (NOT COMPRESS_PROGRAM)
+  set (COMPRESS_PROGRAM gzip CACHE STRING "Set program for compressing documentation" FORCE)
+endif ()
+find_program (COMPRESS_BIN NAMES ${COMPRESS_PROGRAM} DOC "${COMPRESS_PROGRAM} compression program")
+if (NOT COMPRESS_BIN)
+  message (STATUS "${COMPRESS_PROGRAM} program not found, text doc will not be compressed")
+else ()
+  # Deduce COMPRESS_EXT for known compression programs if not set
+  if (NOT COMPRESS_EXT)
+    if (${COMPRESS_PROGRAM} STREQUAL "gzip")
+      set (COMPRESS_EXT "gz")
+    elseif (${COMPRESS_PROGRAM} STREQUAL "bzip2")
+      set (COMPRESS_EXT "bz2")
+    else ()
+      set (COMPRESS_EXT "${COMPRESS_PROGRAM}") # Default: program name (works for xz/lzma)
+    endif ()
+  endif ()
+  # Generate command line args (always add -c to output compressed file to stdout)
+  if (${COMPRESS_PROGRAM} STREQUAL "gzip")
+    # -n for no timestamp in files (reproducible builds)
+    set (COMPRESS_ARGS -c -n)
+  else ()
+    set (COMPRESS_ARGS -c)
+  endif ()
+  message (STATUS "Found ${COMPRESS_BIN} compression program, using file extension .${COMPRESS_EXT}")
+endif ()
+
 # Find dependencies (add install directory to search)
 if (CMAKE_INSTALL_PREFIX)
   set (CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}" ${CMAKE_PREFIX_PATH})
 endif (CMAKE_INSTALL_PREFIX)
 
+include (GNUInstallDirs)
 find_package (bpp-phyl 9.1.3 REQUIRED)
 
 # Subdirectories

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,4 +1,4 @@
-This software needs cmake >= 2.8.12 and a C++11 capable compiler to build
+This software needs cmake >= 2.8.11 and a C++11 capable compiler to build
 
 After installing cmake, run it with the following command:
 $ cmake -DCMAKE_INSTALL_PREFIX=[where to install, for instance /usr/local or $HOME/.local] .

--- a/TestNH/CMakeLists.txt
+++ b/TestNH/CMakeLists.txt
@@ -27,8 +27,6 @@ foreach (target ${testnh-targets})
   else (BUILD_STATIC)
     target_link_libraries (${target} ${BPP_LIBS_SHARED})
   endif (BUILD_STATIC)
-  # Private compile flags
-  target_compile_options (${target} PRIVATE ${private-compile-options})
 endforeach (target)
 
 install (TARGETS ${testnh-targets} DESTINATION bin)

--- a/TestNH/CMakeLists.txt
+++ b/TestNH/CMakeLists.txt
@@ -29,4 +29,4 @@ foreach (target ${testnh-targets})
   endif (BUILD_STATIC)
 endforeach (target)
 
-install (TARGETS ${testnh-targets} DESTINATION bin)
+install (TARGETS ${testnh-targets} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -9,15 +9,15 @@
 # Html doc is proposed as a "html" optional target if makeinfo is found.
 # Pdf doc is proposed as a "pdf" optional target if makeinfo AND texi2dvi are found.
 
-find_program (MAKEINFO NAMES makeinfoi texi2any DOC "makeinfo doc generator program")
+find_program (MAKEINFO NAMES makeinfo texi2any DOC "makeinfo doc generator program")
 if (NOT MAKEINFO)
   message (STATUS "makeinfo program not found: 'info' and 'html' target disabled (builds info/html doc)")
-else (NOT MAKEINFO)
-  message (STATUS "Found makeinfo as '${MAKEINFO}': 'info' and 'html' target enabled (builds info/html doc)")
+else ()
+  message (STATUS "Found ${MAKEINFO}: 'info' and 'html' target enabled (builds info/html doc)")
 
   set (input ${CMAKE_CURRENT_SOURCE_DIR}/testnh.texi)
 
-  # Build and install info page
+  # Build info page
   set (output ${CMAKE_CURRENT_BINARY_DIR}/testnh.info)
   add_custom_command (
     OUTPUT ${output}
@@ -26,10 +26,25 @@ else (NOT MAKEINFO)
     COMMENT "Generating info page"
     VERBATIM
     )
-  install (FILES ${output} DESTINATION share/info)
 
-  # Add "info" target, built with "all" (needed because install will fail if not built).
-  add_custom_target (info ALL DEPENDS ${output})
+  # Install, and have "info" built with "all" (install needs the file to be built)
+  if (NOT COMPRESS_BIN)
+    # Install uncompressed info page
+    install (FILES ${output} DESTINATION ${CMAKE_INSTALL_INFODIR})
+    add_custom_target (info ALL DEPENDS ${output})
+  else ()
+    # Compress and install compressed file
+    set (compressed_ouput ${output}.${COMPRESS_EXT})
+    add_custom_command (
+      OUTPUT ${compressed_ouput}
+      COMMAND ${COMPRESS_BIN} ${COMPRESS_ARGS} ${output} > ${compressed_ouput}
+      DEPENDS ${output}
+      COMMENT "Compressing info page"
+      VERBATIM
+      )
+    install (FILES ${compressed_ouput} DESTINATION ${CMAKE_INSTALL_INFODIR})
+    add_custom_target (info ALL DEPENDS ${compressed_ouput})
+  endif ()
 
   # Also provide a "html" target that builds html doc (not installed, and not part of "all").
   set (output ${CMAKE_CURRENT_BINARY_DIR}/testnh.html)
@@ -56,6 +71,5 @@ else (NOT MAKEINFO)
       VERBATIM
       )
     add_custom_target (pdf DEPENDS ${output})
-  endif (TEXIDVI)
-endif (NOT MAKEINFO)
-
+  endif ()
+endif ()

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -5,32 +5,33 @@
 # Created: 04/10/2011
 
 # Build manpages.
-# In practice, they are just compressed from the text files using gzip.
-# Manpages are built and installed as part of "all" if gzip is found.
+# In practice, they are just compressed from the text files using COMPRESS_PROGRAM
+# Manpages are built and installed as part of "all" if a COMPRESS_PROGRAM is found.
 
-find_program (GZIP NAMES gzip DOC "gzip compression program")
-if (NOT GZIP)
-  message (STATUS "gzip program not found: 'man' target disabled (builds manpages)")
-else (NOT GZIP)
-  message (STATUS "Found gzip as '${GZIP}': 'man' target enabled (builds manpages)")
+# Take all manpages files in the directory
+file (GLOB manpage_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.1)
 
+if (NOT COMPRESS_BIN)
+  # Just install manpages from source
+  foreach (manpage_file ${manpage_files})
+    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/${manpage_file} DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+  endforeach (manpage_file)
+else ()
   # Create a list of manpage targets
   set (manpage-targets)
 
-  # Take all manpages files in the directory
-  file (GLOB manpage_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.1)
   foreach (manpage_file ${manpage_files})
-    # Compress manpage, install, add to manpage list
+    # Compress manpage, install, add to manpage target list
     set (input ${CMAKE_CURRENT_SOURCE_DIR}/${manpage_file})
-    set (output ${CMAKE_CURRENT_BINARY_DIR}/${manpage_file}.gz)
+    set (output ${CMAKE_CURRENT_BINARY_DIR}/${manpage_file}.${COMPRESS_EXT})
     add_custom_command (
       OUTPUT ${output}
-      COMMAND ${GZIP} -c ${input} > ${output}
+      COMMAND ${COMPRESS_BIN} ${COMPRESS_ARGS} ${input} > ${output}
       DEPENDS ${input}
       COMMENT "Compressing manpage ${manpage_file}"
       VERBATIM
       )
-    install (FILES ${output} DESTINATION share/man/man1)
+    install (FILES ${output} DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
     list (APPEND manpage-targets ${output})
     unset (input)
     unset (output)
@@ -38,4 +39,4 @@ else (NOT GZIP)
 
   # Add target "man", built with "all" (needed because install will fail if not built).
   add_custom_target (man ALL DEPENDS ${manpage-targets})
-endif (NOT GZIP)
+endif ()

--- a/testnh.spec
+++ b/testnh.spec
@@ -33,14 +33,14 @@ AutoReq: yes
 AutoProv: yes
 %if 0%{?mdkversion} >= 201100 || %{?distribution} == "Mageia"
 BuildRequires: xz
-%define zipext xz
+%define compress_program xz
 %else
 %if 0%{?mdkversion}
 BuildRequires: lzma
-%define zipext lzma
+%define compress_program lzma
 %else
 BuildRequires: gzip
-%define zipext gz
+%define compress_program gzip
 %endif
 %endif
 
@@ -55,21 +55,10 @@ Includes programs:
 %setup -q
 
 %build
-CFLAGS="-I%{_prefix}/include $RPM_OPT_FLAGS"
-CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=%{_prefix}"
-if [ %{_lib} == 'lib64' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DLIB_SUFFIX=64"
-fi
-if [ %{zipext} == 'lzma' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DDOC_COMPRESS=lzma -DDOC_COMPRESS_EXT=lzma"
-fi
-if [ %{zipext} == 'xz' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DDOC_COMPRESS=xz -DDOC_COMPRESS_EXT=xz"
-fi
-
+CFLAGS="$RPM_OPT_FLAGS"
+CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=%{_prefix} -DCOMPRESS_PROGRAM=%{compress_program}"
 cmake $CMAKE_FLAGS .
 make
-make info
 
 %install
 make DESTDIR=$RPM_BUILD_ROOT install
@@ -84,15 +73,9 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root)
 %doc AUTHORS.txt COPYING.txt INSTALL.txt ChangeLog
-%{_prefix}/bin/testnh
-%{_prefix}/bin/mapnh
-%{_prefix}/bin/partnh
-%{_prefix}/bin/randnh
-%{_prefix}/share/info/testnh.info.%{zipext}
-%{_prefix}/share/man/man1/testnh.1.%{zipext}
-%{_prefix}/share/man/man1/mapnh.1.%{zipext}
-%{_prefix}/share/man/man1/partnh.1.%{zipext}
-%{_prefix}/share/man/man1/randnh.1.%{zipext}
+%{_prefix}/bin/*
+%{_prefix}/share/info/*.info*
+%{_prefix}/share/man/man1/*.1*
 
 %changelog
 * Mon Oct 06 2014 Julien Dutheil <julien.dutheil@univ-montp2.fr> 1.1.0-1


### PR DESCRIPTION
Redhat seems stuck with 2.8.11.
-> Removing the 2.8.12 feature of using target_compile_options.
-> Using the old set CMAKE_CXX_FLAGS

Also simplified the CPACK ignored files.